### PR TITLE
GOALS: Don't parse json if empty.

### DIFF
--- a/lib/gattica/engine.rb
+++ b/lib/gattica/engine.rb
@@ -57,7 +57,7 @@ module Gattica
         json = decompress_gzip(response)
         @user_accounts.each do |ua|
           json['items'].each { |e| ua.set_goals(e) }
-        end
+        end unless (json.blank?)
 
         # Fill in the account name
         response = do_http_get("/analytics/v3/management/accounts?max-results=10000&fields=items(id,name)")


### PR DESCRIPTION
if the call to retrieve the goals returned an empty response, don’t try
to parse it
