### PR TITLE
Fix Data deprecation warning in ruby 2.6

### DIFF
--- a/lib/gattica/data/account.rb
+++ b/lib/gattica/data/account.rb
@@ -1,54 +1,56 @@
 module Gattica
-  class Data::Account
-    include Convertible
+  module Data
+    class Account
+      include Convertible
 
-    attr_reader :id, :updated, :title, :account_id, :account_name,
-                :profile_id, :web_property_id, :goals, :currency,
-                :timezone, :ecommerce, :site_search
+      attr_reader :id, :updated, :title, :account_id, :account_name,
+                  :profile_id, :web_property_id, :goals, :currency,
+                  :timezone, :ecommerce, :site_search
 
-    def initialize(json)
-      @id = json['id']
-      @updated = DateTime.parse(json['updated'])
-      @account_id = json['accountId']
+      def initialize(json)
+        @id = json['id']
+        @updated = DateTime.parse(json['updated'])
+        @account_id = json['accountId']
 
-      @title = json['name']
-      @profile_id = json['id']
-      @web_property_id = json['webPropertyId']
-      @currency = json['currency']
-      @timezone = json['timezone']
-      @ecommerce = json['eCommerceTracking']
-      @site_search = !json['siteSearchQueryParameters'].nil? ? true : false
-      @goals = []
-    end
-
-    def find_account_id(json)
-      json['id']
-    end
-
-    def find_account_name(json)
-      json['name']
-    end
-
-    def find_profile_id(json)
-      json['profileId']
-    end
-
-    def set_account_name(account_feed_entry)
-      if @account_id == find_account_id(account_feed_entry)
-        @account_name = find_account_name(account_feed_entry)
+        @title = json['name']
+        @profile_id = json['id']
+        @web_property_id = json['webPropertyId']
+        @currency = json['currency']
+        @timezone = json['timezone']
+        @ecommerce = json['eCommerceTracking']
+        @site_search = !json['siteSearchQueryParameters'].nil? ? true : false
+        @goals = []
       end
-    end
 
-    def set_goals(goals_feed_entry)
-      if @profile_id == find_profile_id(goals_feed_entry)
-        @goals.push({
-          active: goals_feed_entry['active'],
-          name: goals_feed_entry['name'],
-          value: goals_feed_entry['value'].to_f,
-          type: goals_feed_entry['type'],
-          updated: goals_feed_entry['updated']
-        })
+      def find_account_id(json)
+        json['id']
       end
-    end    
+
+      def find_account_name(json)
+        json['name']
+      end
+
+      def find_profile_id(json)
+        json['profileId']
+      end
+
+      def set_account_name(account_feed_entry)
+        if @account_id == find_account_id(account_feed_entry)
+          @account_name = find_account_name(account_feed_entry)
+        end
+      end
+
+      def set_goals(goals_feed_entry)
+        if @profile_id == find_profile_id(goals_feed_entry)
+          @goals.push({
+            active: goals_feed_entry['active'],
+            name: goals_feed_entry['name'],
+            value: goals_feed_entry['value'].to_f,
+            type: goals_feed_entry['type'],
+            updated: goals_feed_entry['updated']
+          })
+        end
+      end    
+    end
   end
 end

--- a/lib/gattica/data/custom_data_source.rb
+++ b/lib/gattica/data/custom_data_source.rb
@@ -2,24 +2,26 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::CustomDataSource
-    include Convertible
+  module Data
+    class CustomDataSource
+      include Convertible
 
-    attr_reader :id, :name, :description, :type, :upload_type, :import_behavior,
-                :updated, :created, :account_id, :web_property_id
+      attr_reader :id, :name, :description, :type, :upload_type, :import_behavior,
+                  :updated, :created, :account_id, :web_property_id
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @web_property_id = json['webPropertyId']
-      @name = json['name']
-      @type = json['index']
-      @description = json['description']
-      @upload_type = json['upload_type']
-      @import_behavior = json['import_behavior']
-      @updated = DateTime.parse(json['updated']) if json['updated']
-      @created = DateTime.parse(json['created']) if json['created']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @web_property_id = json['webPropertyId']
+        @name = json['name']
+        @type = json['index']
+        @description = json['description']
+        @upload_type = json['upload_type']
+        @import_behavior = json['import_behavior']
+        @updated = DateTime.parse(json['updated']) if json['updated']
+        @created = DateTime.parse(json['created']) if json['created']
+      end
+
     end
-
   end
 end

--- a/lib/gattica/data/custom_dimension.rb
+++ b/lib/gattica/data/custom_dimension.rb
@@ -2,23 +2,24 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::CustomMetric
-    include Convertible
+  module Data
+    class CustomMetric
+      include Convertible
 
-    attr_reader :id, :name, :index, :scope, :active, :updated, :created,
-                :account_id, :web_property_id
+      attr_reader :id, :name, :index, :scope, :active, :updated, :created,
+                  :account_id, :web_property_id
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @web_property_id = json['webPropertyId']
-      @name = json['name']
-      @index = json['index']
-      @scope = json['scope']
-      @active = json['active']
-      @updated = DateTime.parse(json['updated']) if json['updated']
-      @created = DateTime.parse(json['created']) if json['created']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @web_property_id = json['webPropertyId']
+        @name = json['name']
+        @index = json['index']
+        @scope = json['scope']
+        @active = json['active']
+        @updated = DateTime.parse(json['updated']) if json['updated']
+        @created = DateTime.parse(json['created']) if json['created']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/custom_metric.rb
+++ b/lib/gattica/data/custom_metric.rb
@@ -2,26 +2,27 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::CustomMetric
-    include Convertible
+  module Data
+    class CustomMetric
+      include Convertible
 
-    attr_reader :id, :name, :index, :scope, :active, :type, :min_value,
-                :max_value, :updated, :created, :account_id, :web_property_id
+      attr_reader :id, :name, :index, :scope, :active, :type, :min_value,
+                  :max_value, :updated, :created, :account_id, :web_property_id
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @web_property_id = json['webPropertyId']
-      @name = json['name']
-      @index = json['index']
-      @scope = json['scope']
-      @active = json['active']
-      @type = json['type']
-      @min_value = json['min_value']
-      @max_value = json['max_value']
-      @updated = DateTime.parse(json['updated']) if json['updated']
-      @created = DateTime.parse(json['created']) if json['created']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @web_property_id = json['webPropertyId']
+        @name = json['name']
+        @index = json['index']
+        @scope = json['scope']
+        @active = json['active']
+        @type = json['type']
+        @min_value = json['min_value']
+        @max_value = json['max_value']
+        @updated = DateTime.parse(json['updated']) if json['updated']
+        @created = DateTime.parse(json['created']) if json['created']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/experiment.rb
+++ b/lib/gattica/data/experiment.rb
@@ -2,47 +2,48 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Experiment
-    include Convertible
+  module Data
+    class Experiment
+      include Convertible
 
-    attr_reader :id, :account_id, :created, :editable_in_ga_ui, :description,
-                :end_time, :equal_weighting, :internal_web_property_id, :kind,
-                :minimum_experiment_length_in_days, :name, :objective_metric,
-                :optimization_type, :profile_id, :reason_experiment_ended,
-                :rewrite_variation_urls_as_original, :self_link,
-                :serving_framework, :snippet, :start_time, :status,
-                :traffic_coverage, :updated, :web_property_id,
-                :winner_confidence_level, :winner_found, :variations
+      attr_reader :id, :account_id, :created, :editable_in_ga_ui, :description,
+                  :end_time, :equal_weighting, :internal_web_property_id, :kind,
+                  :minimum_experiment_length_in_days, :name, :objective_metric,
+                  :optimization_type, :profile_id, :reason_experiment_ended,
+                  :rewrite_variation_urls_as_original, :self_link,
+                  :serving_framework, :snippet, :start_time, :status,
+                  :traffic_coverage, :updated, :web_property_id,
+                  :winner_confidence_level, :winner_found, :variations
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @created = DateTime.parse(json['created'])
-      @editable_in_ga_ui = json['editableInGaUi']
-      @description = json['description']
-      @end_time = DateTime.parse(json['endTime']) if json['endTime']
-      @equal_weighting = json['equalWeighting']
-      @internal_web_property_id = json['internalWebPropertyId']
-      @kind = json['kind']
-      @minimum_experiment_length_in_days = json['minimumExperimentLengthInDays']
-      @name = json['name']
-      @objective_metric = json['objectiveMetric']
-      @optimization_type = json['optimizationType']
-      @profile_id = json['profileId']
-      @reason_experiment_ended = json['reasonExperimentEnded']
-      @rewrite_variation_urls_as_original = json['rewriteVariationUrlsAsOriginal']
-      @self_link = json['selfLink']
-      @serving_framework = json['servingFramework']
-      @snippet = json['snippet']
-      @start_time = DateTime.parse(json['startTime'])
-      @status = json['status']
-      @traffic_coverage = json['trafficCoverage']
-      @updated = DateTime.parse(json['updated'])
-      @web_property_id = json['webPropertyId']
-      @winner_confidence_level = json['winnerConfidenceLevel']
-      @winner_found = json['winnerFound']
-      @variations = json['variations'].collect { |variant| Variant.new(variant) }
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @created = DateTime.parse(json['created'])
+        @editable_in_ga_ui = json['editableInGaUi']
+        @description = json['description']
+        @end_time = DateTime.parse(json['endTime']) if json['endTime']
+        @equal_weighting = json['equalWeighting']
+        @internal_web_property_id = json['internalWebPropertyId']
+        @kind = json['kind']
+        @minimum_experiment_length_in_days = json['minimumExperimentLengthInDays']
+        @name = json['name']
+        @objective_metric = json['objectiveMetric']
+        @optimization_type = json['optimizationType']
+        @profile_id = json['profileId']
+        @reason_experiment_ended = json['reasonExperimentEnded']
+        @rewrite_variation_urls_as_original = json['rewriteVariationUrlsAsOriginal']
+        @self_link = json['selfLink']
+        @serving_framework = json['servingFramework']
+        @snippet = json['snippet']
+        @start_time = DateTime.parse(json['startTime'])
+        @status = json['status']
+        @traffic_coverage = json['trafficCoverage']
+        @updated = DateTime.parse(json['updated'])
+        @web_property_id = json['webPropertyId']
+        @winner_confidence_level = json['winnerConfidenceLevel']
+        @winner_found = json['winnerFound']
+        @variations = json['variations'].collect { |variant| Variant.new(variant) }
+      end
     end
-
   end
 end

--- a/lib/gattica/data/filter.rb
+++ b/lib/gattica/data/filter.rb
@@ -2,19 +2,20 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Filter
-    include Convertible
+  module Data
+    class Filter
+      include Convertible
 
-    attr_reader :id, :account_id, :created, :updated, :name, :type
+      attr_reader :id, :account_id, :created, :updated, :name, :type
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @name = json['name']
-      @created = DateTime.parse(json['created'])
-      @updated = DateTime.parse(json['updated'])
-      @type = json['type']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @name = json['name']
+        @created = DateTime.parse(json['created'])
+        @updated = DateTime.parse(json['updated'])
+        @type = json['type']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/goal.rb
+++ b/lib/gattica/data/goal.rb
@@ -2,35 +2,36 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Goal
-    include Convertible
+  module Data
+    class Goal
+      include Convertible
 
-    attr_reader :id, :updated, :name, :account_id, :account_name,
-                :profile_id, :web_property_id, :goals, :active, :type,
-                :created, :updated, :value
+      attr_reader :id, :updated, :name, :account_id, :account_name,
+                  :profile_id, :web_property_id, :goals, :active, :type,
+                  :created, :updated, :value
 
-    def initialize(json)
-      @id = json['id']
-      @updated = DateTime.parse(json['updated'])
-      @account_id = find_account_id(json)
+      def initialize(json)
+        @id = json['id']
+        @updated = DateTime.parse(json['updated'])
+        @account_id = find_account_id(json)
 
-      @name = json['name']
-      @profile_id = json['id']
-      @web_property_id = json['webPropertyId']
-      @active = json['active']
-      @type = json['type']
-      @created = DateTime.parse(json['created'])
-      @updated = DateTime.parse(json['updated'])
-      @value = json['value']
+        @name = json['name']
+        @profile_id = json['id']
+        @web_property_id = json['webPropertyId']
+        @active = json['active']
+        @type = json['type']
+        @created = DateTime.parse(json['created'])
+        @updated = DateTime.parse(json['updated'])
+        @value = json['value']
 
-      # @goals = json.search('ga:goal').collect do |goal| {
-      #   active: goal.attributes['active'],
-      #   name: goal.attributes['name'],
-      #   number: goal.attributes['number'].to_i,
-      #   value: goal.attributes['value'].to_f,
-      # }
-      # end
+        # @goals = json.search('ga:goal').collect do |goal| {
+        #   active: goal.attributes['active'],
+        #   name: goal.attributes['name'],
+        #   number: goal.attributes['number'].to_i,
+        #   value: goal.attributes['value'].to_f,
+        # }
+        # end
+      end
     end
-
   end
 end

--- a/lib/gattica/data/profile.rb
+++ b/lib/gattica/data/profile.rb
@@ -2,30 +2,31 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Profile
-    include Convertible
+  module Data
+    class Profile
+      include Convertible
 
-    attr_reader :id, :updated, :title, :account_id, :account_name,
-                :profile_id, :web_property_id, :goals
+      attr_reader :id, :updated, :title, :account_id, :account_name,
+                  :profile_id, :web_property_id, :goals
 
 
-    def initialize(json)
-      @id = json['id']
-      @updated = DateTime.parse(json['updated'])
-      @account_id = find_account_id(json)
+      def initialize(json)
+        @id = json['id']
+        @updated = DateTime.parse(json['updated'])
+        @account_id = find_account_id(json)
 
-      @title = json['name']
-      @profile_id = json['id']
-      @web_property_id = json['webPropertyId']
+        @title = json['name']
+        @profile_id = json['id']
+        @web_property_id = json['webPropertyId']
 
-      # @goals = json.search('ga:goal').collect do |goal| {
-      #   active: goal.attributes['active'],
-      #   name: goal.attributes['name'],
-      #   number: goal.attributes['number'].to_i,
-      #   value: goal.attributes['value'].to_f,
-      # }
-      # end
+        # @goals = json.search('ga:goal').collect do |goal| {
+        #   active: goal.attributes['active'],
+        #   name: goal.attributes['name'],
+        #   number: goal.attributes['number'].to_i,
+        #   value: goal.attributes['value'].to_f,
+        # }
+        # end
+      end
     end
-
   end
 end

--- a/lib/gattica/data/property.rb
+++ b/lib/gattica/data/property.rb
@@ -2,25 +2,26 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Property
-    include Convertible
+  module Data
+    class Property
+      include Convertible
 
-    attr_reader :id, :kind, :created, :updated, :industry_vertical,
-                :level, :name, :profile_count, :account_id, :web_property_id
+      attr_reader :id, :kind, :created, :updated, :industry_vertical,
+                  :level, :name, :profile_count, :account_id, :web_property_id
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @web_property_id = json['internalWebPropertyId']
-      @default_profile_id = json['defaultProfileId']
-      @kind = json['kind']
-      @created = DateTime.parse(json['created'])
-      @updated = DateTime.parse(json['updated'])
-      @industry_vertical = json['industryVertical']
-      @level = json['level']
-      @name = json['name']
-      @profile_count = json['profileCount']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @web_property_id = json['internalWebPropertyId']
+        @default_profile_id = json['defaultProfileId']
+        @kind = json['kind']
+        @created = DateTime.parse(json['created'])
+        @updated = DateTime.parse(json['updated'])
+        @industry_vertical = json['industryVertical']
+        @level = json['level']
+        @name = json['name']
+        @profile_count = json['profileCount']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/segment.rb
+++ b/lib/gattica/data/segment.rb
@@ -2,20 +2,21 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Segment
-    include Convertible
+  module Data
+    class Segment
+      include Convertible
 
-    attr_reader :id, :name, :definition, :updated, :created, :segment_id, :type
+      attr_reader :id, :name, :definition, :updated, :created, :segment_id, :type
 
-    def initialize(json)
-      @id = json['id']
-      @segment_id = json['segmentId']
-      @name = json['name']
-      @definition = json['definition']
-      @type = json['type']
-      @updated = DateTime.parse(json['updated']) if json['updated']
-      @created = DateTime.parse(json['created']) if json['created']
+      def initialize(json)
+        @id = json['id']
+        @segment_id = json['segmentId']
+        @name = json['name']
+        @definition = json['definition']
+        @type = json['type']
+        @updated = DateTime.parse(json['updated']) if json['updated']
+        @created = DateTime.parse(json['created']) if json['created']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/unsampled_report.rb
+++ b/lib/gattica/data/unsampled_report.rb
@@ -2,32 +2,33 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::UnsampledReport
-    include Convertible
+  module Data
+    class UnsampledReport
+      include Convertible
 
-    attr_reader :id, :created, :updated, :title, :start_date, :end_date,
-                :metrics, :dimensions, :filters, :segment, :status,
-                :download_type, :account_id, :web_property_id, :profile_id,
-                :drive_download_details
+      attr_reader :id, :created, :updated, :title, :start_date, :end_date,
+                  :metrics, :dimensions, :filters, :segment, :status,
+                  :download_type, :account_id, :web_property_id, :profile_id,
+                  :drive_download_details
 
-    def initialize(json)
-      @id = json['id']
-      @created = DateTime.parse(json['created'])
-      @updated = DateTime.parse(json['updated'])
-      @account_id = json['accountId']
-      @web_property_id = json['webPropertyId']
-      @profile_id = json['profileId']
-      @title = json['title']
-      @start_date = json['start-date']
-      @end_date = json['end-date']
-      @metrics = json['metrics']
-      @dimensions = json['dimensions']
-      @filters = json['filters']
-      @segment = json['segment']
-      @status = json['status']
-      @download_type = json['downloadType']
-      @drive_download_details = json['driveDownloadDetails']
+      def initialize(json)
+        @id = json['id']
+        @created = DateTime.parse(json['created'])
+        @updated = DateTime.parse(json['updated'])
+        @account_id = json['accountId']
+        @web_property_id = json['webPropertyId']
+        @profile_id = json['profileId']
+        @title = json['title']
+        @start_date = json['start-date']
+        @end_date = json['end-date']
+        @metrics = json['metrics']
+        @dimensions = json['dimensions']
+        @filters = json['filters']
+        @segment = json['segment']
+        @status = json['status']
+        @download_type = json['downloadType']
+        @drive_download_details = json['driveDownloadDetails']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/upload.rb
+++ b/lib/gattica/data/upload.rb
@@ -2,17 +2,18 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Upload
-  	include Convertible
+  module Data
+    class Upload
+    	include Convertible
 
-    attr_reader :id, :account_id, :custom_data_source_id, :status
+      attr_reader :id, :account_id, :custom_data_source_id, :status
 
-    def initialize(json)
-      @id = json['id']
-      @account_id = json['accountId']
-      @custom_data_source_id = json['customDataSourceId']
-      @status = json['status']
+      def initialize(json)
+        @id = json['id']
+        @account_id = json['accountId']
+        @custom_data_source_id = json['customDataSourceId']
+        @status = json['status']
+      end
     end
-
   end
 end

--- a/lib/gattica/data/variant.rb
+++ b/lib/gattica/data/variant.rb
@@ -2,18 +2,19 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::Variant
-  	include Convertible
+  module Data
+    class Variant
+    	include Convertible
 
-    attr_reader :name, :status, :url, :weight, :won
+      attr_reader :name, :status, :url, :weight, :won
 
-    def initialize(json)
-      @name = json['name']
-      @status = json['status']
-      @url = json['url']
-      @weight = json['weight']
-      @won = json['won']
+      def initialize(json)
+        @name = json['name']
+        @status = json['status']
+        @url = json['url']
+        @weight = json['weight']
+        @won = json['won']
+      end
     end
-
   end
 end

--- a/lib/gattica/meta_data.rb
+++ b/lib/gattica/meta_data.rb
@@ -2,24 +2,25 @@ require 'rubygems'
 require 'json'
 
 module Gattica
-  class Data::MetaData
-    include Convertible
+  module Data
+    class MetaData
+      include Convertible
 
-    attr_reader :id, :kind, :type, :data_type, :group, :status, :ui_name,
-                :app_ui_name, :description, :allowed_in_segments
+      attr_reader :id, :kind, :type, :data_type, :group, :status, :ui_name,
+                  :app_ui_name, :description, :allowed_in_segments
 
-    def initialize(json)
-      @id = json['id']
-      @kind = json['kind']
-      @type = json['attributes']['type']
-      @data_type = json['attributes']['dataType']
-      @group = json['attributes']['group']
-      @status = json['attributes']['status']
-      @ui_name = json['attributes']['uiName']
-      @app_ui_name = json['attributes']['appUiName']
-      @description = json['attributes']['description']
-      @allowed_in_segments = json['attributes']['allowedInSegments']
+      def initialize(json)
+        @id = json['id']
+        @kind = json['kind']
+        @type = json['attributes']['type']
+        @data_type = json['attributes']['dataType']
+        @group = json['attributes']['group']
+        @status = json['attributes']['status']
+        @ui_name = json['attributes']['uiName']
+        @app_ui_name = json['attributes']['appUiName']
+        @description = json['attributes']['description']
+        @allowed_in_segments = json['attributes']['allowedInSegments']
+      end
     end
-
   end
 end


### PR DESCRIPTION
When running on ruby 2.6, a lot of deprecation warnings is raised, like:

```ruby
warning: constant ::Data is deprecated
```

This PR fixes it by changing the code like 

```ruby
class Data::Something
```

to

```ruby
module Data
  class Something
    # ...
   end
end
```